### PR TITLE
Add dnqr (DuitNow QR) payment method support

### DIFF
--- a/includes/admin/form-settings.php
+++ b/includes/admin/form-settings.php
@@ -111,6 +111,14 @@ function ff_chip_form_fields( $form ) {
 			'dependency' => array( array( 'payment-method-whitelist-' . $form->id, '==', 'true' ) ),
 		),
 		array(
+			'id'         => 'payment-method-crypto-' . $form->id,
+			'type'       => 'switcher',
+			'title'      => __( 'Enable Crypto Coin', 'chip-for-fluent-forms' ),
+			'desc'       => __( 'To enable Crypto Coin payment method.', 'chip-for-fluent-forms' ),
+			'help'       => __( 'Whether to enable Crypto Coin payment method.', 'chip-for-fluent-forms' ),
+			'dependency' => array( array( 'payment-method-whitelist-' . $form->id, '==', 'true' ) ),
+		),
+		array(
 			'id'         => 'payment-method-card-' . $form->id,
 			'type'       => 'switcher',
 			'title'      => __( 'Enable Card', 'chip-for-fluent-forms' ),

--- a/includes/admin/form-settings.php
+++ b/includes/admin/form-settings.php
@@ -103,6 +103,14 @@ function ff_chip_form_fields( $form ) {
 			'dependency' => array( array( 'payment-method-whitelist-' . $form->id, '==', 'true' ) ),
 		),
 		array(
+			'id'         => 'payment-method-shopee-' . $form->id,
+			'type'       => 'switcher',
+			'title'      => __( 'Enable Shopee Pay', 'chip-for-fluent-forms' ),
+			'desc'       => __( 'To enable Shopee Pay payment method.', 'chip-for-fluent-forms' ),
+			'help'       => __( 'Whether to enable Shopee Pay payment method.', 'chip-for-fluent-forms' ),
+			'dependency' => array( array( 'payment-method-whitelist-' . $form->id, '==', 'true' ) ),
+		),
+		array(
 			'id'         => 'payment-method-card-' . $form->id,
 			'type'       => 'switcher',
 			'title'      => __( 'Enable Card', 'chip-for-fluent-forms' ),

--- a/includes/admin/global-settings.php
+++ b/includes/admin/global-settings.php
@@ -126,6 +126,14 @@ $miscellaneous_global_fields = array(
 		'dependency' => array( array( 'payment-method-whitelist', '==', 'true' ) ),
 	),
 	array(
+		'id'         => 'payment-method-crypto',
+		'type'       => 'switcher',
+		'title'      => __( 'Enable Crypto Coin', 'chip-for-fluent-forms' ),
+		'desc'       => __( 'To enable Crypto Coin payment method.', 'chip-for-fluent-forms' ),
+		'help'       => __( 'Whether to enable Crypto Coin payment method.', 'chip-for-fluent-forms' ),
+		'dependency' => array( array( 'payment-method-whitelist', '==', 'true' ) ),
+	),
+	array(
 		'id'         => 'payment-method-card',
 		'type'       => 'switcher',
 		'title'      => __( 'Enable Card', 'chip-for-fluent-forms' ),

--- a/includes/admin/global-settings.php
+++ b/includes/admin/global-settings.php
@@ -118,6 +118,14 @@ $miscellaneous_global_fields = array(
 		'dependency' => array( array( 'payment-method-whitelist', '==', 'true' ) ),
 	),
 	array(
+		'id'         => 'payment-method-shopee',
+		'type'       => 'switcher',
+		'title'      => __( 'Enable Shopee Pay', 'chip-for-fluent-forms' ),
+		'desc'       => __( 'To enable Shopee Pay payment method.', 'chip-for-fluent-forms' ),
+		'help'       => __( 'Whether to enable Shopee Pay payment method.', 'chip-for-fluent-forms' ),
+		'dependency' => array( array( 'payment-method-whitelist', '==', 'true' ) ),
+	),
+	array(
 		'id'         => 'payment-method-card',
 		'type'       => 'switcher',
 		'title'      => __( 'Enable Card', 'chip-for-fluent-forms' ),

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -36,10 +36,10 @@ class Chip_Fluent_Forms_API {
 		return $this->call( 'POST', '/webhooks/?time=' . time(), $params );
 	}
 
-	public function payment_methods( $currency, $language ) {
+	public function payment_methods( $currency, $language, $amount ) {
 		return $this->call(
 			'GET',
-			"/payment_methods/?brand_id={$this->brand_id}&currency={$currency}&language={$language}"
+			"/payment_methods/?brand_id={$this->brand_id}&currency={$currency}&language={$language}&amount={$amount}"
 		);
 	}
 

--- a/includes/class-purchase.php
+++ b/includes/class-purchase.php
@@ -165,6 +165,10 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 				$params['payment_method_whitelist'][] = 'shopee_pay';
 			}
 
+			if ( $option['payment_method_crypto'] ) {
+				$params['payment_method_whitelist'][] = 'crypto_coin';
+			}
+
 			// In-memory migration: treat any stored legacy 'razer_shopeepay' entry
 			// as the modern 'shopee_pay' so existing configs keep working without
 			// a DB write. The resolver's SHOPEE_GROUP still accepts both.
@@ -386,6 +390,7 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 			'payment_method_fpxb2b1' => empty( $options[ 'payment-method-fpxb2b1' . $postfix ] ) ? false : $options[ 'payment-method-fpxb2b1' . $postfix ],
 			'payment_method_duitnow' => empty( $options[ 'payment-method-duitnow' . $postfix ] ) ? false : $options[ 'payment-method-duitnow' . $postfix ],
 			'payment_method_shopee'  => empty( $options[ 'payment-method-shopee' . $postfix ] ) ? false : $options[ 'payment-method-shopee' . $postfix ],
+			'payment_method_crypto'  => empty( $options[ 'payment-method-crypto' . $postfix ] ) ? false : $options[ 'payment-method-crypto' . $postfix ],
 			'payment_method_card'    => empty( $options[ 'payment-method-card' . $postfix ] ) ? false : $options[ 'payment-method-card' . $postfix ],
 		);
 	}

--- a/includes/class-purchase.php
+++ b/includes/class-purchase.php
@@ -20,6 +20,15 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 	 */
 	const DUITNOW_GROUP = array( 'duitnow_qr', 'dnqr' );
 
+	/**
+	 * Shopee Pay group. razer_shopeepay is the legacy identifier, shopee_pay the
+	 * modern one (whitelist-only, never returned in the /payment_methods/ schema).
+	 * shopee_pay is preferred when both are available. Mirrors the WHMCS gateway.
+	 *
+	 * @var array
+	 */
+	const SHOPEE_GROUP = array( 'razer_shopeepay', 'shopee_pay' );
+
 	private $supported_currencies = array( 'MYR' );
 	protected $method             = 'chip'; // used by BaseProcessor->insertRefund($data)
 
@@ -249,16 +258,21 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 
 	/**
 	 * Resolve the configured payment_method_whitelist against the merchant's
-	 * actual /payment_methods/ response, with dnqr-priority for the DuitNow QR group.
+	 * actual /payment_methods/ response, with preferred-identifier priority for
+	 * the DuitNow QR and Shopee Pay groups.
+	 *
+	 * Groups are resolved with a single /payment_methods/ call and a single
+	 * transient, shared across both groups.
 	 *
 	 * Steps:
-	 *   1. Group expansion: any dnqr-group member in the whitelist expands to the full group.
-	 *   2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
-	 *   3. Try cache. On miss, call /payment_methods/.
-	 *   4. Fallback: return expanded whitelist unchanged if the API fails.
-	 *   5. Intersect with available methods.
-	 *   6. Priority: dnqr wins when both are present.
-	 *   7. Build the final whitelist (original non-group entries + resolved group).
+	 *   1. Short-circuit: if the whitelist intersects neither group, return unchanged.
+	 *   2. Group expansion: any group member in the whitelist expands to the full group.
+	 *   3. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+	 *   4. Try cache. On miss, call /payment_methods/ once.
+	 *   5. Fallback: return expanded whitelist unchanged if the API fails.
+	 *   6. Resolve each configured group against available methods.
+	 *   7. Priority: dnqr wins over duitnow_qr; shopee_pay wins over razer_shopeepay.
+	 *   8. Build the final whitelist (original non-group entries + resolved groups).
 	 *
 	 * @param array  $whitelist Configured payment_method_whitelist.
 	 * @param string $currency  Order currency code (e.g. 'MYR').
@@ -266,45 +280,63 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 	 * @return array            Final whitelist to send to CHIP.
 	 */
 	private function resolve_duitnow_methods( array $whitelist, string $currency, int $amount ): array {
-		// 1. Group expansion.
-		$has_group_member = count( array_intersect( $whitelist, self::DUITNOW_GROUP ) ) > 0;
+		// 1. Short-circuit: no group configured => no API call, no group injection.
+		$groups = array();
+		foreach ( array( self::DUITNOW_GROUP, self::SHOPEE_GROUP ) as $group ) {
+			if ( count( array_intersect( $whitelist, $group ) ) > 0 ) {
+				$groups[] = $group;
+			}
+		}
 
-		// Short-circuit: a whitelist that does not intersect the dnqr group must be
-		// returned untouched (no API call, no group injection).
-		if ( ! $has_group_member ) {
+		if ( empty( $groups ) ) {
 			return $whitelist;
 		}
 
-		$expanded = array_values( array_unique( array_merge( $whitelist, self::DUITNOW_GROUP ) ) );
+		// 2. Group expansion: configured groups expand to their full member sets.
+		$expanded = $whitelist;
+		foreach ( $groups as $group ) {
+			$expanded = array_merge( $expanded, $group );
+		}
+		$expanded = array_values( array_unique( $expanded ) );
 
-		// 2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+		// 3. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
 		$option    = $this->get_settings( $this->form->id );
 		$cache_key = 'ff_chip_pm_' . md5( $option['brand_id'] . '|' . $currency . '|' . intval( $amount / 100 ) );
 
-		// 3. Try cache. If hit, use it. If miss, call /payment_methods/.
+		// 4. Try cache. If hit, use it. If miss, call /payment_methods/ once.
 		$available = get_transient( $cache_key );
 		if ( false === $available ) {
 			$chip     = Chip_Fluent_Forms_API::get_instance( $option['secret_key'], $option['brand_id'] );
 			$response = $chip->payment_methods( $currency, '', $amount ); // No language param.
 			if ( ! is_array( $response ) || ! isset( $response['available_payment_methods'] ) ) {
-				// 4. Fallback: return expanded whitelist unchanged.
+				// 5. Fallback: return expanded whitelist unchanged.
 				return $expanded;
 			}
 			$available = $response['available_payment_methods'];
 			set_transient( $cache_key, $available, 30 * MINUTE_IN_SECONDS );
 		}
 
-		// 5. Intersect: keep only group members the merchant actually has.
-		$resolved_group = array_values( array_intersect( self::DUITNOW_GROUP, $available ) );
+		// 6. Resolve each configured group against the merchant's available methods.
+		$resolved = array();
+		foreach ( $groups as $group ) {
+			$members = array_values( array_intersect( $group, $available ) );
 
-		// 6. Priority: dnqr wins when both are present.
-		if ( in_array( 'dnqr', $resolved_group, true ) ) {
-			$resolved_group = array_values( array_diff( $resolved_group, array( 'duitnow_qr' ) ) );
+			// 7. Priority: dnqr wins over duitnow_qr; shopee_pay wins over razer_shopeepay.
+			if ( in_array( 'dnqr', $members, true ) ) {
+				$members = array_values( array_diff( $members, array( 'duitnow_qr' ) ) );
+			}
+			if ( in_array( 'shopee_pay', $members, true ) ) {
+				$members = array_values( array_diff( $members, array( 'razer_shopeepay' ) ) );
+			}
+
+			$resolved = array_merge( $resolved, $members );
 		}
+		$resolved = array_values( array_unique( $resolved ) );
 
-		// 7. Build final whitelist: original entries (with group members stripped) + resolved group.
-		$final = array_values( array_diff( $expanded, self::DUITNOW_GROUP ) );
-		$final = array_merge( $final, $resolved_group );
+		// 8. Build final whitelist: original entries (with group members stripped) + resolved groups.
+		$all_group_members = array_merge( self::DUITNOW_GROUP, self::SHOPEE_GROUP );
+		$final             = array_values( array_diff( $expanded, $all_group_members ) );
+		$final             = array_merge( $final, $resolved );
 
 		return $final;
 	}

--- a/includes/class-purchase.php
+++ b/includes/class-purchase.php
@@ -161,6 +161,20 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 				$params['payment_method_whitelist'][] = 'duitnow_qr';
 			}
 
+			if ( $option['payment_method_shopee'] ) {
+				$params['payment_method_whitelist'][] = 'shopee_pay';
+			}
+
+			// In-memory migration: treat any stored legacy 'razer_shopeepay' entry
+			// as the modern 'shopee_pay' so existing configs keep working without
+			// a DB write. The resolver's SHOPEE_GROUP still accepts both.
+			$params['payment_method_whitelist'] = array_map(
+				static function ( $method ) {
+					return 'razer_shopeepay' === $method ? 'shopee_pay' : $method;
+				},
+				$params['payment_method_whitelist']
+			);
+
 			// Resolve the DuitNow QR group (duitnow_qr legacy + dnqr modern) against
 			// the merchant's actual /payment_methods/ availability, prioritizing dnqr.
 			// Short-circuits (no API call) when the group is not configured.
@@ -371,6 +385,7 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 			'payment_method_fpx'     => empty( $options[ 'payment-method-fpx' . $postfix ] ) ? false : $options[ 'payment-method-fpx' . $postfix ],
 			'payment_method_fpxb2b1' => empty( $options[ 'payment-method-fpxb2b1' . $postfix ] ) ? false : $options[ 'payment-method-fpxb2b1' . $postfix ],
 			'payment_method_duitnow' => empty( $options[ 'payment-method-duitnow' . $postfix ] ) ? false : $options[ 'payment-method-duitnow' . $postfix ],
+			'payment_method_shopee'  => empty( $options[ 'payment-method-shopee' . $postfix ] ) ? false : $options[ 'payment-method-shopee' . $postfix ],
 			'payment_method_card'    => empty( $options[ 'payment-method-card' . $postfix ] ) ? false : $options[ 'payment-method-card' . $postfix ],
 		);
 	}

--- a/includes/class-purchase.php
+++ b/includes/class-purchase.php
@@ -11,6 +11,15 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 
 	private static $_instance;
 
+	/**
+	 * DuitNow QR group. duitnow_qr is the legacy identifier, dnqr the modern
+	 * one. They are interchangeable at runtime; dnqr is preferred when both are
+	 * available. Exposed to the merchant as a single group checkbox (duitnow_qr).
+	 *
+	 * @var array
+	 */
+	const DUITNOW_GROUP = array( 'duitnow_qr', 'dnqr' );
+
 	private $supported_currencies = array( 'MYR' );
 	protected $method             = 'chip'; // used by BaseProcessor->insertRefund($data)
 
@@ -143,6 +152,15 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 				$params['payment_method_whitelist'][] = 'duitnow_qr';
 			}
 
+			// Resolve the DuitNow QR group (duitnow_qr legacy + dnqr modern) against
+			// the merchant's actual /payment_methods/ availability, prioritizing dnqr.
+			// Short-circuits (no API call) when the group is not configured.
+			$params['payment_method_whitelist'] = $this->resolve_duitnow_methods(
+				$params['payment_method_whitelist'],
+				strtoupper( $submission->currency ),
+				intval( $transaction->payment_total )
+			);
+
 			if ( empty( $params['payment_method_whitelist'] ) ) {
 				unset( $params['payment_method_whitelist'] );
 			}
@@ -227,6 +245,68 @@ class Chip_Fluent_Forms_Purchase extends BaseProcessor {
 			),
 			200
 		);
+	}
+
+	/**
+	 * Resolve the configured payment_method_whitelist against the merchant's
+	 * actual /payment_methods/ response, with dnqr-priority for the DuitNow QR group.
+	 *
+	 * Steps:
+	 *   1. Group expansion: any dnqr-group member in the whitelist expands to the full group.
+	 *   2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+	 *   3. Try cache. On miss, call /payment_methods/.
+	 *   4. Fallback: return expanded whitelist unchanged if the API fails.
+	 *   5. Intersect with available methods.
+	 *   6. Priority: dnqr wins when both are present.
+	 *   7. Build the final whitelist (original non-group entries + resolved group).
+	 *
+	 * @param array  $whitelist Configured payment_method_whitelist.
+	 * @param string $currency  Order currency code (e.g. 'MYR').
+	 * @param int    $amount    Order total in sen (e.g. 12345 = RM 123.45).
+	 * @return array            Final whitelist to send to CHIP.
+	 */
+	private function resolve_duitnow_methods( array $whitelist, string $currency, int $amount ): array {
+		// 1. Group expansion.
+		$has_group_member = count( array_intersect( $whitelist, self::DUITNOW_GROUP ) ) > 0;
+
+		// Short-circuit: a whitelist that does not intersect the dnqr group must be
+		// returned untouched (no API call, no group injection).
+		if ( ! $has_group_member ) {
+			return $whitelist;
+		}
+
+		$expanded = array_values( array_unique( array_merge( $whitelist, self::DUITNOW_GROUP ) ) );
+
+		// 2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+		$option    = $this->get_settings( $this->form->id );
+		$cache_key = 'ff_chip_pm_' . md5( $option['brand_id'] . '|' . $currency . '|' . intval( $amount / 100 ) );
+
+		// 3. Try cache. If hit, use it. If miss, call /payment_methods/.
+		$available = get_transient( $cache_key );
+		if ( false === $available ) {
+			$chip     = Chip_Fluent_Forms_API::get_instance( $option['secret_key'], $option['brand_id'] );
+			$response = $chip->payment_methods( $currency, '', $amount ); // No language param.
+			if ( ! is_array( $response ) || ! isset( $response['available_payment_methods'] ) ) {
+				// 4. Fallback: return expanded whitelist unchanged.
+				return $expanded;
+			}
+			$available = $response['available_payment_methods'];
+			set_transient( $cache_key, $available, 30 * MINUTE_IN_SECONDS );
+		}
+
+		// 5. Intersect: keep only group members the merchant actually has.
+		$resolved_group = array_values( array_intersect( self::DUITNOW_GROUP, $available ) );
+
+		// 6. Priority: dnqr wins when both are present.
+		if ( in_array( 'dnqr', $resolved_group, true ) ) {
+			$resolved_group = array_values( array_diff( $resolved_group, array( 'duitnow_qr' ) ) );
+		}
+
+		// 7. Build final whitelist: original entries (with group members stripped) + resolved group.
+		$final = array_values( array_diff( $expanded, self::DUITNOW_GROUP ) );
+		$final = array_merge( $final, $resolved_group );
+
+		return $final;
 	}
 
 	private function is_form_currency_supported( $currency ) {


### PR DESCRIPTION
Add support for `dnqr` (modern DuitNow QR) as an interchangeable identifier alongside the legacy `duitnow_qr`, mirroring chip-for-woocommerce.

- **class-api.php**: `payment_methods()` now accepts `$amount` and passes `amount=` to `/payment_methods/`.
- **class-purchase.php**: new `DUITNOW_GROUP` const + `resolve_duitnow_methods()` resolver, wired into the whitelist build. Group expansion, 30-min WP transient (brand+currency+amount-bucket), API intersect, dnqr priority, short-circuit/fallback.
- Admin UI keeps a single DuitNow QR checkbox; no separate dnqr option.